### PR TITLE
power: Fixup typo in 8939 cpu4 timer rate

### DIFF
--- a/power/performance.h
+++ b/power/performance.h
@@ -150,7 +150,7 @@ enum INTERACTIVE_TIMER_RATE_LVL_CPU0_8939 {
 /* This timer rate applicable to cpu4
     across 8939 series chipset */
 enum INTERACTIVE_TIMER_RATE_LVL_CPU4_8939 {
-    TR_MS_CPU4_500 = 0x3B0CD,
+    TR_MS_CPU4_500 = 0x3BCD,
     TR_MS_CPU4_100 = 0x3BF5,
     TR_MS_CPU4_50 = 0x3BFA,
     TR_MS_CPU4_30 = 0x3BFC,


### PR DESCRIPTION
This difference has been here since the initial commit of this
code, so the side effects of it are unknown or not observable.

Change-Id: I4f1ef2a27face628550fa8498242a002846a7896