### PR TITLE
power-8916: Simplify missed soc_id check in 9e40a0e

### DIFF
--- a/power/power-8916.c
+++ b/power/power-8916.c
@@ -315,17 +315,12 @@ int  set_interactive_override(struct power_module *module __unused, int on)
 
     } else {
         /* Display on. */
-      switch(is_target_8916()){
-         case 8916:
-         {
+      if (is_target_8916()) {
           if ((strncmp(governor, INTERACTIVE_GOVERNOR, strlen(INTERACTIVE_GOVERNOR)) == 0) &&
                 (strlen(governor) == strlen(INTERACTIVE_GOVERNOR))) {
             undo_hint_action(DISPLAY_STATE_HINT_ID);
          }
-         }
-         break ;
-         default :
-         {
+      } else {
 
           if ((strncmp(governor, INTERACTIVE_GOVERNOR, strlen(INTERACTIVE_GOVERNOR)) == 0) &&
                 (strlen(governor) == strlen(INTERACTIVE_GOVERNOR))) {
@@ -347,8 +342,6 @@ int  set_interactive_override(struct power_module *module __unused, int on)
              undo_hint_action(DISPLAY_STATE_HINT_ID);
           }
 
-        }
-         break ;
       } /* End of check condition during the DISPLAY ON case */
    }
     return HINT_HANDLED;


### PR DESCRIPTION
Since is_target_8916 doesn't return "8916" anymore every device
would be stuck at 960MHz as minimum frequency without this.

Change-Id: I3c33798f03e2c2dec11e5283e09b6c0cae8af67d